### PR TITLE
Fix missing reference errors when loading assetbundle information

### DIFF
--- a/Packages/UGF.AssetBundles/Editor/AssetBundleDrawer.cs
+++ b/Packages/UGF.AssetBundles/Editor/AssetBundleDrawer.cs
@@ -43,6 +43,11 @@ namespace UGF.AssetBundles.Editor
 
             Clear();
 
+            foreach (string assetName in assetBundle.GetAllAssetNames())
+            {
+                assetBundle.LoadAsset(assetName);
+            }
+
             m_drawer.Set(assetBundle);
         }
 

--- a/Packages/UGF.AssetBundles/Editor/AssetBundleFileUtility.cs
+++ b/Packages/UGF.AssetBundles/Editor/AssetBundleFileUtility.cs
@@ -16,6 +16,11 @@ namespace UGF.AssetBundles.Editor
 
             try
             {
+                foreach (string assetName in assetBundle.GetAllAssetNames())
+                {
+                    assetBundle.LoadAsset(assetName);
+                }
+
                 BuildPipeline.GetCRCForAssetBundle(path, out uint crc);
 
                 AssetBundleFileInfo info = Create(assetBundle, crc);

--- a/UGF.AssetBundles.Editor.csproj.DotSettings
+++ b/UGF.AssetBundles.Editor.csproj.DotSettings
@@ -1,2 +1,2 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
-	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=packages_005Cpackage_005Ceditor/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/CodeInspection/NamespaceProvider/NamespaceFoldersToSkip/=packages_005Cugf_002Eassetbundles_005Ceditor/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
- Fix missing reference errors by loading assetbundle all known assets when getting information.