### PR TITLE
Change to draw assets and dependencies as paged collection in assetbundle information

### DIFF
--- a/Assets/UGF.AssetBundles.Editor.Tests/TestAssetBundleFileInfoDrawerAsset.cs
+++ b/Assets/UGF.AssetBundles.Editor.Tests/TestAssetBundleFileInfoDrawerAsset.cs
@@ -1,4 +1,5 @@
-﻿using UnityEditor;
+﻿using System.Collections.Generic;
+using UnityEditor;
 using UnityEngine;
 
 namespace UGF.AssetBundles.Editor.Tests
@@ -18,21 +19,19 @@ namespace UGF.AssetBundles.Editor.Tests
         {
             m_drawer.Enable();
 
-            var assets = new[]
-            {
-                new AssetBundleFileInfo.AssetInfo("Asset 0", typeof(Object), "Address"),
-                new AssetBundleFileInfo.AssetInfo("Asset 1", typeof(Object), "Address"),
-                new AssetBundleFileInfo.AssetInfo("Asset 2", typeof(Object), "Address")
-            };
+            var assets = new List<AssetBundleFileInfo.AssetInfo>();
 
-            string[] dependencies = new[]
+            for (int i = 0; i < 20; i++)
             {
-                "Test 0",
-                "Test 1",
-                "Test 2",
-                "Test 3",
-                "Test 4"
-            };
+                assets.Add(new AssetBundleFileInfo.AssetInfo($"Asset {i}", typeof(Object), "Address"));
+            }
+
+            var dependencies = new List<string>();
+
+            for (int i = 0; i < 20; i++)
+            {
+                dependencies.Add($"Dependency {i}");
+            }
 
             m_info = new AssetBundleFileInfo("Test", 15, assets, dependencies, true);
             m_drawer.Set(m_info);

--- a/Packages/UGF.AssetBundles/Editor/AssetBundleDrawer.cs
+++ b/Packages/UGF.AssetBundles/Editor/AssetBundleDrawer.cs
@@ -70,10 +70,7 @@ namespace UGF.AssetBundles.Editor
         {
             if (HasData)
             {
-                using (new EditorGUI.DisabledScope(true))
-                {
-                    m_drawer.DrawGUILayout();
-                }
+                m_drawer.DrawGUILayout();
             }
             else
             {

--- a/Packages/UGF.AssetBundles/Editor/AssetBundleFileDrawer.cs
+++ b/Packages/UGF.AssetBundles/Editor/AssetBundleFileDrawer.cs
@@ -31,11 +31,12 @@ namespace UGF.AssetBundles.Editor
         public bool DisplayMenuClear { get; set; } = true;
         public bool DisplayMenuDebug { get; set; } = true;
         public bool HasData { get { return m_drawerNormal.HasData || m_drawerDebug.HasData; } }
+        public AssetBundleFileInfoDrawer DrawerNormal { get { return m_drawerNormal; } }
+        public AssetBundleDrawer DrawerDebug { get { return m_drawerDebug; } }
 
         private readonly AssetBundleFileInfoDrawer m_drawerNormal = new AssetBundleFileInfoDrawer();
         private readonly AssetBundleDrawer m_drawerDebug = new AssetBundleDrawer();
         private bool m_displayDebug;
-        private bool m_foldout;
         private Styles m_styles;
 
         private class Styles

--- a/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfoContainerEditor.cs
+++ b/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfoContainerEditor.cs
@@ -1,4 +1,4 @@
-﻿using UGF.EditorTools.Editor.IMGUI;
+﻿using UGF.EditorTools.Editor.IMGUI.Pages;
 using UnityEditor;
 
 namespace UGF.AssetBundles.Editor
@@ -9,23 +9,16 @@ namespace UGF.AssetBundles.Editor
         private SerializedProperty m_propertyName;
         private SerializedProperty m_propertyCrc;
         private SerializedProperty m_propertyIsStreamedSceneAssetBundle;
-        private ReorderableListDrawer m_listAssets;
-        private ReorderableListDrawer m_listDependencies;
+        private PagesCollectionDrawer m_listAssets;
+        private PagesCollectionDrawer m_listDependencies;
 
         private void OnEnable()
         {
             m_propertyName = serializedObject.FindProperty("m_name");
             m_propertyCrc = serializedObject.FindProperty("m_crc");
             m_propertyIsStreamedSceneAssetBundle = serializedObject.FindProperty("m_isStreamedSceneAssetBundle");
-            m_listAssets = new ReorderableListDrawer(serializedObject.FindProperty("m_assets"));
-            m_listDependencies = new ReorderableListDrawer(serializedObject.FindProperty("m_dependencies"));
-
-            m_listAssets.List.displayAdd = false;
-            m_listAssets.List.displayRemove = false;
-            m_listAssets.List.draggable = false;
-            m_listDependencies.List.displayAdd = false;
-            m_listDependencies.List.displayRemove = false;
-            m_listDependencies.List.draggable = false;
+            m_listAssets = new PagesCollectionDrawer(serializedObject.FindProperty("m_assets"));
+            m_listDependencies = new PagesCollectionDrawer(serializedObject.FindProperty("m_dependencies"));
 
             m_listAssets.Enable();
             m_listDependencies.Enable();
@@ -39,6 +32,8 @@ namespace UGF.AssetBundles.Editor
 
         public override void OnInspectorGUI()
         {
+            serializedObject.Update();
+
             EditorGUILayout.PropertyField(m_propertyName);
             EditorGUILayout.PropertyField(m_propertyCrc);
             EditorGUILayout.PropertyField(m_propertyIsStreamedSceneAssetBundle);

--- a/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfoDrawer.cs
+++ b/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfoDrawer.cs
@@ -8,6 +8,7 @@ namespace UGF.AssetBundles.Editor
     public class AssetBundleFileInfoDrawer : DrawerBase
     {
         public bool HasData { get { return m_drawer.HasEditor; } }
+        public bool DisplayAsReadOnly { get; set; }
 
         private readonly EditorDrawer m_drawer = new EditorDrawer();
         private AssetBundleFileInfoContainer m_container;
@@ -64,7 +65,7 @@ namespace UGF.AssetBundles.Editor
         {
             if (HasData)
             {
-                using (new EditorGUI.DisabledScope(true))
+                using (new EditorGUI.DisabledScope(DisplayAsReadOnly))
                 {
                     m_drawer.DrawGUILayout();
                 }


### PR DESCRIPTION
- Add `AssetBundleFileDrawer.DrawerNormal` and `DrawerDebug` properties to access drawers for each mode.
- Add `AssetBundleFileInfoDrawer.DisplayAsReadOnly` property to determine whether to display information in readonly GUI mode.
- Change _AssetBundle Information_ to display _Assets_ and _Dependencies_ collections as collection with pages.