### PR TITLE
Add display of known asset names in assetbundle information

### DIFF
--- a/Assets/UGF.AssetBundles.Editor.Tests/TestAssetBundleFileInfoDrawerAsset.cs
+++ b/Assets/UGF.AssetBundles.Editor.Tests/TestAssetBundleFileInfoDrawerAsset.cs
@@ -20,12 +20,18 @@ namespace UGF.AssetBundles.Editor.Tests
             m_drawer.Enable();
 
             var assetNames = new List<string>();
+            var scenePaths = new List<string>();
             var assets = new List<AssetBundleFileInfo.AssetInfo>();
             var dependencies = new List<string>();
 
             for (int i = 0; i < 20; i++)
             {
                 assetNames.Add($"Asset Name {i}");
+            }
+
+            for (int i = 0; i < 20; i++)
+            {
+                scenePaths.Add($"Scene Path {i}");
             }
 
             for (int i = 0; i < 20; i++)
@@ -38,7 +44,7 @@ namespace UGF.AssetBundles.Editor.Tests
                 dependencies.Add($"Dependency {i}");
             }
 
-            m_info = new AssetBundleFileInfo("Test", 15, assetNames, assets, dependencies, true);
+            m_info = new AssetBundleFileInfo("Test", 15, assetNames, scenePaths, assets, dependencies, true);
             m_drawer.Set(m_info);
         }
 

--- a/Assets/UGF.AssetBundles.Editor.Tests/TestAssetBundleFileInfoDrawerAsset.cs
+++ b/Assets/UGF.AssetBundles.Editor.Tests/TestAssetBundleFileInfoDrawerAsset.cs
@@ -19,21 +19,26 @@ namespace UGF.AssetBundles.Editor.Tests
         {
             m_drawer.Enable();
 
+            var assetNames = new List<string>();
             var assets = new List<AssetBundleFileInfo.AssetInfo>();
+            var dependencies = new List<string>();
+
+            for (int i = 0; i < 20; i++)
+            {
+                assetNames.Add($"Asset Name {i}");
+            }
 
             for (int i = 0; i < 20; i++)
             {
                 assets.Add(new AssetBundleFileInfo.AssetInfo($"Asset {i}", typeof(Object), "Address"));
             }
 
-            var dependencies = new List<string>();
-
             for (int i = 0; i < 20; i++)
             {
                 dependencies.Add($"Dependency {i}");
             }
 
-            m_info = new AssetBundleFileInfo("Test", 15, assets, dependencies, true);
+            m_info = new AssetBundleFileInfo("Test", 15, assetNames, assets, dependencies, true);
             m_drawer.Set(m_info);
         }
 

--- a/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfo.cs
+++ b/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfo.cs
@@ -8,6 +8,7 @@ namespace UGF.AssetBundles.Editor
         public string Name { get; }
         public uint Crc { get; }
         public IReadOnlyList<string> AssetNames { get; }
+        public IReadOnlyList<string> ScenePaths { get; }
         public IReadOnlyList<AssetInfo> Assets { get; }
         public IReadOnlyList<string> Dependencies { get; }
         public bool IsStreamedSceneAssetBundle { get; }
@@ -28,17 +29,18 @@ namespace UGF.AssetBundles.Editor
             }
         }
 
-        public AssetBundleFileInfo(string name, uint crc, bool isStreamedSceneAssetBundle) : this(name, crc, Array.Empty<string>(), Array.Empty<AssetInfo>(), Array.Empty<string>(), isStreamedSceneAssetBundle)
+        public AssetBundleFileInfo(string name, uint crc, bool isStreamedSceneAssetBundle) : this(name, crc, Array.Empty<string>(), Array.Empty<string>(), Array.Empty<AssetInfo>(), Array.Empty<string>(), isStreamedSceneAssetBundle)
         {
         }
 
-        public AssetBundleFileInfo(string name, uint crc, IReadOnlyList<string> assetNames, IReadOnlyList<AssetInfo> assets, IReadOnlyList<string> dependencies, bool isStreamedSceneAssetBundle)
+        public AssetBundleFileInfo(string name, uint crc, IReadOnlyList<string> assetNames, IReadOnlyList<string> scenePaths, IReadOnlyList<AssetInfo> assets, IReadOnlyList<string> dependencies, bool isStreamedSceneAssetBundle)
         {
             if (string.IsNullOrEmpty(name)) throw new ArgumentException("Value cannot be null or empty.", nameof(name));
 
             Name = name;
             Crc = crc;
             AssetNames = assetNames ?? throw new ArgumentNullException(nameof(assetNames));
+            ScenePaths = scenePaths ?? throw new ArgumentNullException(nameof(scenePaths));
             Assets = assets ?? throw new ArgumentNullException(nameof(assets));
             Dependencies = dependencies ?? throw new ArgumentNullException(nameof(dependencies));
             IsStreamedSceneAssetBundle = isStreamedSceneAssetBundle;

--- a/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfo.cs
+++ b/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfo.cs
@@ -7,6 +7,7 @@ namespace UGF.AssetBundles.Editor
     {
         public string Name { get; }
         public uint Crc { get; }
+        public IReadOnlyList<string> AssetNames { get; }
         public IReadOnlyList<AssetInfo> Assets { get; }
         public IReadOnlyList<string> Dependencies { get; }
         public bool IsStreamedSceneAssetBundle { get; }
@@ -27,16 +28,17 @@ namespace UGF.AssetBundles.Editor
             }
         }
 
-        public AssetBundleFileInfo(string name, uint crc, bool isStreamedSceneAssetBundle) : this(name, crc, Array.Empty<AssetInfo>(), Array.Empty<string>(), isStreamedSceneAssetBundle)
+        public AssetBundleFileInfo(string name, uint crc, bool isStreamedSceneAssetBundle) : this(name, crc, Array.Empty<string>(), Array.Empty<AssetInfo>(), Array.Empty<string>(), isStreamedSceneAssetBundle)
         {
         }
 
-        public AssetBundleFileInfo(string name, uint crc, IReadOnlyList<AssetInfo> assets, IReadOnlyList<string> dependencies, bool isStreamedSceneAssetBundle)
+        public AssetBundleFileInfo(string name, uint crc, IReadOnlyList<string> assetNames, IReadOnlyList<AssetInfo> assets, IReadOnlyList<string> dependencies, bool isStreamedSceneAssetBundle)
         {
             if (string.IsNullOrEmpty(name)) throw new ArgumentException("Value cannot be null or empty.", nameof(name));
 
             Name = name;
             Crc = crc;
+            AssetNames = assetNames ?? throw new ArgumentNullException(nameof(assetNames));
             Assets = assets ?? throw new ArgumentNullException(nameof(assets));
             Dependencies = dependencies ?? throw new ArgumentNullException(nameof(dependencies));
             IsStreamedSceneAssetBundle = isStreamedSceneAssetBundle;

--- a/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfoContainer.cs
+++ b/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfoContainer.cs
@@ -9,12 +9,14 @@ namespace UGF.AssetBundles.Editor
         [SerializeField] private string m_name;
         [SerializeField] private uint m_crc;
         [SerializeField] private bool m_isStreamedSceneAssetBundle;
+        [SerializeField] private List<string> m_assetNames = new List<string>();
         [SerializeField] private List<AssetInfo> m_assets = new List<AssetInfo>();
         [SerializeField] private List<string> m_dependencies = new List<string>();
 
         public string Name { get { return m_name; } set { m_name = value; } }
         public uint Crc { get { return m_crc; } set { m_crc = value; } }
         public bool IsStreamedSceneAssetBundle { get { return m_isStreamedSceneAssetBundle; } set { m_isStreamedSceneAssetBundle = value; } }
+        public List<string> AssetNames { get { return m_assetNames; } }
         public List<AssetInfo> Assets { get { return m_assets; } }
         public List<string> Dependencies { get { return m_dependencies; } }
 

--- a/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfoContainer.cs
+++ b/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfoContainer.cs
@@ -10,6 +10,7 @@ namespace UGF.AssetBundles.Editor
         [SerializeField] private uint m_crc;
         [SerializeField] private bool m_isStreamedSceneAssetBundle;
         [SerializeField] private List<string> m_assetNames = new List<string>();
+        [SerializeField] private List<string> m_scenePaths = new List<string>();
         [SerializeField] private List<AssetInfo> m_assets = new List<AssetInfo>();
         [SerializeField] private List<string> m_dependencies = new List<string>();
 
@@ -17,6 +18,7 @@ namespace UGF.AssetBundles.Editor
         public uint Crc { get { return m_crc; } set { m_crc = value; } }
         public bool IsStreamedSceneAssetBundle { get { return m_isStreamedSceneAssetBundle; } set { m_isStreamedSceneAssetBundle = value; } }
         public List<string> AssetNames { get { return m_assetNames; } }
+        public List<string> ScenePaths { get { return m_scenePaths; } }
         public List<AssetInfo> Assets { get { return m_assets; } }
         public List<string> Dependencies { get { return m_dependencies; } }
 

--- a/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfoContainerEditor.cs
+++ b/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfoContainerEditor.cs
@@ -10,6 +10,7 @@ namespace UGF.AssetBundles.Editor
         private SerializedProperty m_propertyCrc;
         private SerializedProperty m_propertyIsStreamedSceneAssetBundle;
         private PagesCollectionDrawer m_listAssetNames;
+        private PagesCollectionDrawer m_listScenePaths;
         private PagesCollectionDrawer m_listAssets;
         private PagesCollectionDrawer m_listDependencies;
 
@@ -19,10 +20,12 @@ namespace UGF.AssetBundles.Editor
             m_propertyCrc = serializedObject.FindProperty("m_crc");
             m_propertyIsStreamedSceneAssetBundle = serializedObject.FindProperty("m_isStreamedSceneAssetBundle");
             m_listAssetNames = new PagesCollectionDrawer(serializedObject.FindProperty("m_assetNames"));
+            m_listScenePaths = new PagesCollectionDrawer(serializedObject.FindProperty("m_scenePaths"));
             m_listAssets = new PagesCollectionDrawer(serializedObject.FindProperty("m_assets"));
             m_listDependencies = new PagesCollectionDrawer(serializedObject.FindProperty("m_dependencies"));
 
             m_listAssetNames.Enable();
+            m_listScenePaths.Enable();
             m_listAssets.Enable();
             m_listDependencies.Enable();
         }
@@ -30,6 +33,7 @@ namespace UGF.AssetBundles.Editor
         private void OnDisable()
         {
             m_listAssetNames.Disable();
+            m_listScenePaths.Disable();
             m_listAssets.Disable();
             m_listDependencies.Disable();
         }
@@ -43,6 +47,7 @@ namespace UGF.AssetBundles.Editor
             EditorGUILayout.PropertyField(m_propertyIsStreamedSceneAssetBundle);
 
             m_listAssetNames.DrawGUILayout();
+            m_listScenePaths.DrawGUILayout();
             m_listAssets.DrawGUILayout();
             m_listDependencies.DrawGUILayout();
         }

--- a/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfoContainerEditor.cs
+++ b/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfoContainerEditor.cs
@@ -9,6 +9,7 @@ namespace UGF.AssetBundles.Editor
         private SerializedProperty m_propertyName;
         private SerializedProperty m_propertyCrc;
         private SerializedProperty m_propertyIsStreamedSceneAssetBundle;
+        private PagesCollectionDrawer m_listAssetNames;
         private PagesCollectionDrawer m_listAssets;
         private PagesCollectionDrawer m_listDependencies;
 
@@ -17,15 +18,18 @@ namespace UGF.AssetBundles.Editor
             m_propertyName = serializedObject.FindProperty("m_name");
             m_propertyCrc = serializedObject.FindProperty("m_crc");
             m_propertyIsStreamedSceneAssetBundle = serializedObject.FindProperty("m_isStreamedSceneAssetBundle");
+            m_listAssetNames = new PagesCollectionDrawer(serializedObject.FindProperty("m_assetNames"));
             m_listAssets = new PagesCollectionDrawer(serializedObject.FindProperty("m_assets"));
             m_listDependencies = new PagesCollectionDrawer(serializedObject.FindProperty("m_dependencies"));
 
+            m_listAssetNames.Enable();
             m_listAssets.Enable();
             m_listDependencies.Enable();
         }
 
         private void OnDisable()
         {
+            m_listAssetNames.Disable();
             m_listAssets.Disable();
             m_listDependencies.Disable();
         }
@@ -38,6 +42,7 @@ namespace UGF.AssetBundles.Editor
             EditorGUILayout.PropertyField(m_propertyCrc);
             EditorGUILayout.PropertyField(m_propertyIsStreamedSceneAssetBundle);
 
+            m_listAssetNames.DrawGUILayout();
             m_listAssets.DrawGUILayout();
             m_listDependencies.DrawGUILayout();
         }

--- a/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfoContainerUtility.cs
+++ b/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfoContainerUtility.cs
@@ -15,6 +15,7 @@ namespace UGF.AssetBundles.Editor
             container.Crc = info.Crc;
             container.IsStreamedSceneAssetBundle = info.IsStreamedSceneAssetBundle;
             container.AssetNames.AddRange(info.AssetNames);
+            container.ScenePaths.AddRange(info.ScenePaths);
             container.Dependencies.AddRange(info.Dependencies);
 
             for (int i = 0; i < info.Assets.Count; i++)

--- a/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfoContainerUtility.cs
+++ b/Packages/UGF.AssetBundles/Editor/AssetBundleFileInfoContainerUtility.cs
@@ -14,6 +14,7 @@ namespace UGF.AssetBundles.Editor
             container.Name = info.Name;
             container.Crc = info.Crc;
             container.IsStreamedSceneAssetBundle = info.IsStreamedSceneAssetBundle;
+            container.AssetNames.AddRange(info.AssetNames);
             container.Dependencies.AddRange(info.Dependencies);
 
             for (int i = 0; i < info.Assets.Count; i++)

--- a/Packages/UGF.AssetBundles/Editor/AssetBundleFileUtility.cs
+++ b/Packages/UGF.AssetBundles/Editor/AssetBundleFileUtility.cs
@@ -38,9 +38,12 @@ namespace UGF.AssetBundles.Editor
             if (assetBundle == null) throw new ArgumentNullException(nameof(assetBundle));
 
             string name = assetBundle.name;
+            var assetNames = new List<string>();
             var assets = new List<AssetBundleFileInfo.AssetInfo>();
             var dependencies = new List<string>();
             bool isStreamedSceneAssetBundle = assetBundle.isStreamedSceneAssetBundle;
+
+            assetNames.AddRange(assetBundle.GetAllAssetNames());
 
             var serializedObject = new SerializedObject(assetBundle);
             SerializedProperty propertyPreloadTable = serializedObject.FindProperty("m_PreloadTable");
@@ -89,7 +92,7 @@ namespace UGF.AssetBundles.Editor
                 dependencies.Add(propertyElement.stringValue);
             }
 
-            return new AssetBundleFileInfo(name, crc, assets, dependencies, isStreamedSceneAssetBundle);
+            return new AssetBundleFileInfo(name, crc, assetNames, assets, dependencies, isStreamedSceneAssetBundle);
         }
     }
 }

--- a/Packages/UGF.AssetBundles/Editor/AssetBundleFileUtility.cs
+++ b/Packages/UGF.AssetBundles/Editor/AssetBundleFileUtility.cs
@@ -39,11 +39,13 @@ namespace UGF.AssetBundles.Editor
 
             string name = assetBundle.name;
             var assetNames = new List<string>();
+            var scenePaths = new List<string>();
             var assets = new List<AssetBundleFileInfo.AssetInfo>();
             var dependencies = new List<string>();
             bool isStreamedSceneAssetBundle = assetBundle.isStreamedSceneAssetBundle;
 
             assetNames.AddRange(assetBundle.GetAllAssetNames());
+            scenePaths.AddRange(assetBundle.GetAllScenePaths());
 
             var serializedObject = new SerializedObject(assetBundle);
             SerializedProperty propertyPreloadTable = serializedObject.FindProperty("m_PreloadTable");
@@ -92,7 +94,7 @@ namespace UGF.AssetBundles.Editor
                 dependencies.Add(propertyElement.stringValue);
             }
 
-            return new AssetBundleFileInfo(name, crc, assetNames, assets, dependencies, isStreamedSceneAssetBundle);
+            return new AssetBundleFileInfo(name, crc, assetNames, scenePaths, assets, dependencies, isStreamedSceneAssetBundle);
         }
     }
 }


### PR DESCRIPTION
- Add `AssetBundleFileInfo.AssetNames` and `ScenePaths` properties with collection of all known asset names and scene paths from assetbundle.